### PR TITLE
Zolk 20 hadoop catalog and dependency updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           name: Release ${{ steps.get_package_version.outputs.package_version }}
           tag: ${{ steps.get_package_version.outputs.package_version }}
-          artifacts: "target/kafka-connect-iceberg-sink-*-shaded.jar"
+          artifacts: "target/kafka-connect-iceberg-sink-*-plugin.zip"
           bodyFile: ./release_body.md
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@
 - Replaced maven-shade plugin with maven-assembly. To add hadoop default configuration files
 - Integrated updates from https://github.com/memiiso/debezium-server-iceberg
 - Updated Iceberg to 1.0.0
-- Updated to Iceberg Spark 3.3 runtime
-- Updated to Kafka Connect API 3.2.3
+- Updated to Kafka Connect API 3.2.2
+
+### Version Compatibility
+
+This Iceberg Sink depends on a Spark 3.2 Runtime, which depends on a specific jackson minor version. 
+Kafka Connect >= 3.2.3 has updated the jackson version to an incompatible minor release (2.13)
 
 ## [0.1.3] - 2022-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased]
 
-- Added Spark core,catalyst as compile dependencies. Needed for writing file based HadoopCatalog
 - Replaced maven-shade plugin with maven-assembly. To add hadoop default configuration files
-- Updated iceberg-spark-runtime.version to 0.13.2
+- Integrated updates from https://github.com/memiiso/debezium-server-iceberg
+- - Updated Iceberg to 0.14.0
 
 ## [0.1.3] - 2022-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Replaced maven-shade plugin with maven-assembly. To add hadoop default configuration files
 - Integrated updates from https://github.com/memiiso/debezium-server-iceberg
-- - Updated Iceberg to 0.14.0
+- - Updated Iceberg to 1.0.0
+- - Updated to Iceberg Spark 3.3 runtime
 
 ## [0.1.3] - 2022-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- Added Spark core,catalyst as compile dependencies. Needed for writing file based HadoopCatalog
+- Replaced maven-shade plugin with maven-assembly. To add hadoop default configuration files
+- Updated iceberg-spark-runtime.version to 0.13.2
+
 ## [0.1.3] - 2022-04-11
 
 -   Logger levels changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 - Replaced maven-shade plugin with maven-assembly. To add hadoop default configuration files
 - Integrated updates from https://github.com/memiiso/debezium-server-iceberg
-- - Updated Iceberg to 1.0.0
-- - Updated to Iceberg Spark 3.3 runtime
+- Updated Iceberg to 1.0.0
+- Updated to Iceberg Spark 3.3 runtime
+- Updated to Kafka Connect API 3.2.3
 
 ## [0.1.3] - 2022-04-11
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,28 @@ mvn clean package
 
 ## Usage
 
-1. Copy `kafka-connect-iceberg-sink-0.1-SNAPSHOT-shaded.jar` into Kafka Connect plugins directory. [Kafka Connect installing plugins](https://docs.confluent.io/home/connect/self-managed/userguide.html#connect-installing-plugins)
+### Configuration reference
+
+| Key                  | Type    | Default value  | Description                                                                                                                        |
+|----------------------|---------|----------------|------------------------------------------------------------------------------------------------------------------------------------|
+| upsert               | boolean | true           | When *true* Iceberg rows will be updated based on table primary key. When *false* all modification will be added as separate rows. |
+| upsert.keep-deletes  | boolean | true           | When *true* delete operation will leave a tombstone that will have only a primary key and *__deleted** flag set to true            |
+| upsert.dedup-column  | String  | __source_ts_ms | Column used to check which state is newer during upsert                                                                            | 
+| upsert.op-column     | String  | __op           | Column used to check which state is newer during upsert when *upsert.dedup-column* is not enough to resolve                        |
+| allow-field-addition | boolean | true           | When *true* sink will be adding new columns to Iceberg tables on schema changes                                                    |
+| table.auto-create    | boolean | false          | When *true* sink will automatically create new Iceberg tables                                                                      |
+| table.namespace      | String  | default        | Table namespace. In Glue it will be used as database name                                                                          |
+| table.prefix         | String  | *empty string* | Prefix added to all table names                                                                                                    |
+| table.write-format   | String  | parquet        | Format used for Iceberg tables                                                                                                     |
+| iceberg.name         | String  | default        | Iceberg catalog name                                                                                                               |
+| iceberg.catalog-impl | String  | *null*         | Iceberg catalog implementation (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time    |
+| iceberg.type         | String  | *null*         | Iceberg catalog type (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time)             |
+| iceberg.*            |         |                | All properties with this prefix will be passed to Iceberg Catalog implementation                                                   |
+
+
+### REST / Manual based installation
+
+1. Copy content of `kafka-connect-iceberg-sink-0.1.4-SNAPSHOT-plugin.zip` into Kafka Connect plugins directory. [Kafka Connect installing plugins](https://docs.confluent.io/home/connect/self-managed/userguide.html#connect-installing-plugins)
 
 2. POST `<kafka_connect_host>:<kafka_connect_port>/connectors`
 ```json
@@ -52,7 +73,7 @@ docker run -it --name connect --net=host -p 8083:8083 \
   -e BOOTSTRAP_SERVERS=localhost:9092 \
   -e CONNECT_TOPIC_CREATION_ENABLE=true \
   -v ~/.aws/config:/kafka/.aws/config \
-  -v ./target/kafka-connect-iceberg-sink-0.1.1-SNAPSHOT-shaded.jar:/kafka/connect/kafka-connect-iceberg-sink-0.1.1-SNAPSHOT-shaded.jar \
+  -v ./target/plugin/kafka-connect-iceberg-sink:/kafka/connect/kafka-connect-iceberg-sink \
   debezium/connect
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,14 +14,14 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <!-- versions -->
-        <kafka.connect.version>3.1.0</kafka.connect.version>
+        <kafka.connect.version>3.2.3</kafka.connect.version>
         <iceberg.version>1.0.0</iceberg.version>
         <debezium.version>1.9.5.Final</debezium.version>
         <hadoop.version>3.3.3</hadoop.version>
         <awssdk.version>2.17.295</awssdk.version>
-        <!-- Have to use earlier version due to Spark dependency: Scala module 2.12.3 requires Jackson Databind version >= 2.12.0 and < 2.13.0 -->
-        <!-- jackson is also provided by kafka connect runtime -->
-        <jackson.version>2.12.3</jackson.version>
+        <!-- spark 3.3.1_2.13 includes jackson 2.13.4 which requires Jackson Databind version >= 2.13.0 and < 2.14.0 -->
+        <!-- jackson is also provided by kafka connect-runtime -> pinning to the same version -->
+        <jackson.version>2.13.3</jackson.version>
 
         <!-- utils -->
         <slf4j-api.version>1.7.36</slf4j-api.version>
@@ -301,6 +301,19 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptors>
@@ -313,6 +326,26 @@
                         <phase>package</phase> <!-- bind to the packaging phase -->
                         <goals>
                             <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-assembly</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <tasks>
+                                <echo message="unpack plugin assembly" />
+                                <unzip src="target/kafka-connect-iceberg-sink-0.1.4-SNAPSHOT-plugin.zip" dest="target/plugin" />
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
         <!-- versions -->
         <kafka.connect.version>3.1.0</kafka.connect.version>
-        <iceberg.version>0.14.0</iceberg.version>
+        <iceberg.version>1.0.0</iceberg.version>
         <debezium.version>1.9.5.Final</debezium.version>
         <hadoop.version>3.3.3</hadoop.version>
         <awssdk.version>2.17.131</awssdk.version>
@@ -33,7 +33,7 @@
         <postgresql.version>42.3.3</postgresql.version>
         <minio.version>8.3.6</minio.version>
         <awaitility.version>4.1.1</awaitility.version>
-        <spark.version>3.2.2</spark.version>
+        <spark.version>3.3.1</spark.version>
         <fest-assert.version>1.4</fest-assert.version>
 
         <!-- plugins -->
@@ -72,7 +72,7 @@
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-spark-runtime-3.2_2.12</artifactId>
+            <artifactId>iceberg-spark-runtime-3.3_2.13</artifactId>
             <version>${iceberg.version}</version>
         </dependency>
 
@@ -219,7 +219,7 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.12</artifactId>
+            <artifactId>spark-core_2.13</artifactId>
             <version>${spark.version}</version>
             <scope>test</scope>
             <exclusions>
@@ -235,7 +235,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.12</artifactId>
+            <artifactId>spark-sql_2.13</artifactId>
             <version>${spark.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getindata</groupId>
     <artifactId>kafka-connect-iceberg-sink</artifactId>
-    <version>0.1.4-SNAPSHOT</version>
+    <version>0.1.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -14,15 +14,15 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <!-- versions -->
-        <kafka.connect.version>3.2.3</kafka.connect.version>
+        <kafka.connect.version>3.2.2</kafka.connect.version>
         <iceberg.version>1.0.0</iceberg.version>
-        <debezium.version>1.9.5.Final</debezium.version>
+        <debezium.version>1.9.7.Final</debezium.version>
         <hadoop.version>3.3.3</hadoop.version>
         <awssdk.version>2.17.295</awssdk.version>
         <hive.version>3.1.3</hive.version>
-        <!-- spark 3.3.1_2.13 includes jackson 2.13.4 which requires Jackson Databind version >= 2.13.0 and < 2.14.0 -->
+        <!-- spark 3.2.2_2.13 includes jackson 2.12.3 which requires Jackson Databind version >= 2.12.0 and < 2.13.0 -->
         <!-- jackson is also provided by kafka connect-runtime -> pinning to the same version -->
-        <jackson.version>2.13.3</jackson.version>
+        <jackson.version>2.12.6</jackson.version>
 
         <!-- utils -->
         <slf4j-api.version>1.7.36</slf4j-api.version>
@@ -34,7 +34,7 @@
         <postgresql.version>42.3.3</postgresql.version>
         <minio.version>8.3.6</minio.version>
         <awaitility.version>4.1.1</awaitility.version>
-        <spark.version>3.3.1</spark.version>
+        <spark.version>3.2.2</spark.version>
         <fest-assert.version>1.4</fest-assert.version>
 
         <!-- plugins -->
@@ -73,7 +73,7 @@
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-spark-runtime-3.3_2.13</artifactId>
+            <artifactId>iceberg-spark-runtime-3.2_2.13</artifactId>
             <version>${iceberg.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <iceberg.version>1.0.0</iceberg.version>
         <debezium.version>1.9.5.Final</debezium.version>
         <hadoop.version>3.3.3</hadoop.version>
-        <awssdk.version>2.17.131</awssdk.version>
+        <awssdk.version>2.17.295</awssdk.version>
         <!-- Have to use earlier version due to Spark dependency: Scala module 2.12.3 requires Jackson Databind version >= 2.12.0 and < 2.13.0 -->
         <!-- jackson is also provided by kafka connect runtime -->
         <jackson.version>2.12.3</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <!-- test -->
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <assertj.version>3.22.0</assertj.version>
-        <testcontainers.version>1.16.3</testcontainers.version>
+        <testcontainers.version>1.17.5</testcontainers.version>
         <postgresql.version>42.3.3</postgresql.version>
         <minio.version>8.3.6</minio.version>
         <awaitility.version>4.1.1</awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -334,15 +334,20 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>unpack-assembly</id>
                         <phase>package</phase>
                         <configuration>
-                            <tasks>
+                            <target>
                                 <echo message="unpack plugin assembly" />
-                                <unzip src="target/kafka-connect-iceberg-sink-0.1.4-SNAPSHOT-plugin.zip" dest="target/plugin" />
-                            </tasks>
+                                <unzip dest="target/plugin">
+                                    <fileset dir="${project.build.directory}">
+                                        <filename regex="kafka-connect-iceberg-sink-.*-plugin.zip" />
+                                    </fileset>
+                                </unzip>
+                            </target>
                         </configuration>
                         <goals>
                             <goal>run</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.getindata</groupId>
     <artifactId>kafka-connect-iceberg-sink</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.1.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -15,13 +15,15 @@
 
         <!-- versions -->
         <kafka.connect.version>3.1.0</kafka.connect.version>
-        <iceberg-spark-runtime.version>0.13.1</iceberg-spark-runtime.version>
+        <iceberg-spark-runtime.version>0.13.2</iceberg-spark-runtime.version>
+        <spark.version>3.2.1</spark.version>
         <debezium.version>1.8.1.Final</debezium.version>
         <parquet.version>1.12.2</parquet.version>
         <hadoop.version>3.3.1</hadoop.version>
         <awssdk.version>2.17.131</awssdk.version>
         <!-- Have to use earlier version due to Spark dependency: Scala module 2.12.3 requires Jackson Databind version >= 2.12.0 and < 2.13.0 -->
-        <jackson.version>2.12.6</jackson.version>
+        <!-- jackson is also provided by kafka connect runtime -->
+        <jackson.version>2.12.3</jackson.version>
 
         <!-- utils -->
         <slf4j-api.version>1.7.36</slf4j-api.version>
@@ -33,7 +35,6 @@
         <postgresql.version>42.3.3</postgresql.version>
         <minio.version>8.3.6</minio.version>
         <awaitility.version>4.1.1</awaitility.version>
-        <spark.version>3.2.1</spark.version>
         <fest-assert.version>1.4</fest-assert.version>
 
         <!-- plugins -->
@@ -49,17 +50,53 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <version>${kafka.connect.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-json</artifactId>
             <version>${kafka.connect.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-spark-runtime-3.2_2.12</artifactId>
             <version>${iceberg-spark-runtime.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
+            <version>${spark.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-runtime</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_2.12</artifactId>
+            <version>${spark.version}</version>
         </dependency>
 
         <dependency>
@@ -137,17 +174,6 @@
             <version>${awssdk.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
         <!-- utils -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -222,12 +248,6 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.12</artifactId>
-            <version>${spark.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>
             <version>${spark.version}</version>
             <scope>test</scope>
@@ -294,17 +314,19 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>${maven-shade-plugin.version}</version>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/src.xml</descriptor>
+                    </descriptors>
+                </configuration>
                 <executions>
                     <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
                         <goals>
-                            <goal>shade</goal>
+                            <goal>single</goal>
                         </goals>
-                        <configuration>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,9 @@
 
         <!-- versions -->
         <kafka.connect.version>3.1.0</kafka.connect.version>
-        <iceberg-spark-runtime.version>0.13.2</iceberg-spark-runtime.version>
-        <spark.version>3.2.1</spark.version>
-        <debezium.version>1.8.1.Final</debezium.version>
-        <parquet.version>1.12.2</parquet.version>
-        <hadoop.version>3.3.1</hadoop.version>
+        <iceberg.version>0.14.0</iceberg.version>
+        <debezium.version>1.9.5.Final</debezium.version>
+        <hadoop.version>3.3.3</hadoop.version>
         <awssdk.version>2.17.131</awssdk.version>
         <!-- Have to use earlier version due to Spark dependency: Scala module 2.12.3 requires Jackson Databind version >= 2.12.0 and < 2.13.0 -->
         <!-- jackson is also provided by kafka connect runtime -->
@@ -35,6 +33,7 @@
         <postgresql.version>42.3.3</postgresql.version>
         <minio.version>8.3.6</minio.version>
         <awaitility.version>4.1.1</awaitility.version>
+        <spark.version>3.2.2</spark.version>
         <fest-assert.version>1.4</fest-assert.version>
 
         <!-- plugins -->
@@ -74,41 +73,13 @@
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-spark-runtime-3.2_2.12</artifactId>
-            <version>${iceberg-spark-runtime.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.12</artifactId>
-            <version>${spark.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-client-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-client-runtime</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-catalyst_2.12</artifactId>
-            <version>${spark.version}</version>
+            <version>${iceberg.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
             <version>${debezium.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-hadoop-bundle</artifactId>
-            <version>${parquet.version}</version>
         </dependency>
 
         <dependency>
@@ -246,6 +217,22 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.12</artifactId>
+            <version>${spark.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-client-runtime</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.12</artifactId>

--- a/src/main/assembly/src.xml
+++ b/src/main/assembly/src.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>plugin</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>${project.artifactId}</outputDirectory>
+            <unpack>false</unpack>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <excludes>
+                <!-- Exclude dependencies of Kafka APIs, since they will be available in the runtime -->
+                <exclude>com.fasterxml.jackson.core:jackson-core:*</exclude>
+                <exclude>com.fasterxml.jackson.core:jackson-databind:*</exclude>
+                <exclude>com.fasterxml.jackson.core:jackson-annotations:*</exclude>
+                <exclude>com.fasterxml.jackson.datatype:jackson-datatype-jsr310:*</exclude>
+            </excludes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>${project.artifactId}</outputDirectory>
+            <unpack>false</unpack>
+            <includes>
+                <include>${project.groupId}:${project.artifactId}:*</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <outputDirectory>${project.artifactId}</outputDirectory>
+            <includes>
+                <include>README*</include>
+                <include>CHANGELOG*</include>
+                <include>CONTRIBUTING*</include>
+                <include>LICENSE*</include>
+            </includes>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/src/main/assembly/src.xml
+++ b/src/main/assembly/src.xml
@@ -19,7 +19,6 @@
                 <exclude>com.fasterxml.jackson.core:jackson-core:*</exclude>
                 <exclude>com.fasterxml.jackson.core:jackson-databind:*</exclude>
                 <exclude>com.fasterxml.jackson.core:jackson-annotations:*</exclude>
-                <exclude>com.fasterxml.jackson.datatype:jackson-datatype-jsr310:*</exclude>
             </excludes>
         </dependencySet>
         <dependencySet>

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/BaseDeltaTaskWriter.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/BaseDeltaTaskWriter.java
@@ -25,6 +25,8 @@ public abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
     private final Schema schema;
     private final Schema deleteSchema;
     private final InternalRecordWrapper wrapper;
+
+    private final InternalRecordWrapper keyWrapper;
     private final boolean upsert;
     private final boolean upsertKeepDeletes;
 
@@ -42,6 +44,7 @@ public abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
         this.schema = schema;
         this.deleteSchema = TypeUtil.select(schema, Sets.newHashSet(equalityFieldIds));
         this.wrapper = new InternalRecordWrapper(schema.asStruct());
+        this.keyWrapper = new InternalRecordWrapper(deleteSchema.asStruct());
         this.upsert = upsert;
         this.upsertKeepDeletes = upsertKeepDeletes;
     }
@@ -57,7 +60,6 @@ public abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
         RowDataDeltaWriter writer = route(row);
         if (upsert && !row.getField("__op").equals(CREATE.getCode())) {// anything which not an insert is upsert
             writer.delete(row);
-            //System.out.println("->" + row);
         }
         // if its deleted row and upsertKeepDeletes = true then add deleted record to target table
         // else deleted records are deleted from target table
@@ -77,6 +79,11 @@ public abstract class BaseDeltaTaskWriter extends BaseTaskWriter<Record> {
         @Override
         protected StructLike asStructLike(Record data) {
             return wrapper.wrap(data);
+        }
+
+        @Override
+        protected StructLike asStructLikeKey(Record data) {
+            return keyWrapper.wrap(data);
         }
     }
 }

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/IcebergTableOperator.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/IcebergTableOperator.java
@@ -34,6 +34,18 @@ public class IcebergTableOperator {
         this.writerFactory = writerFactory;
     }
 
+    /**
+     * Adds list of events to iceberg table.
+     * <p>
+     * If field addition enabled then it groups list of change events by their schema first. Then adds new fields to
+     * iceberg table if there is any. And then follows with adding data to the table.
+     * <p>
+     * New fields are detected using CDC event schema, since events are grouped by their schemas it uses single
+     * event to find-out schema for the whole list of events.
+     *
+     * @param icebergTable
+     * @param events
+     */
     public void addToTable(Table icebergTable, List<IcebergChangeEvent> events) {
 
         // when operation mode is not upsert deduplicate the events to avoid inserting duplicate row
@@ -83,6 +95,19 @@ public class IcebergTableOperator {
     }
 
 
+    /**
+     * This is used to deduplicate events within given batch.
+     * <p>
+     * Forex ample a record can be updated multiple times in the source. for example insert followed by update and
+     * delete. for this case we need to only pick last change event for the row.
+     * <p>
+     * Its used when `upsert` feature enabled (when the consumer operating non append mode) which means it should not add
+     * duplicate records to target table.
+     *
+     * @param lhs
+     * @param rhs
+     * @return
+     */
     private int compareByTsThenOp(JsonNode lhs, JsonNode rhs) {
 
         String upsertDedupColumn = configuration.getUpsertDedupColumn();
@@ -101,6 +126,15 @@ public class IcebergTableOperator {
         return CdcOperation.getByCode(lhs.get(configuration.getUpsertOpColumn()).asText("c"));
     }
 
+    /**
+     * If given schema contains new fields compared to target table schema then it adds new fields to target iceberg
+     * table.
+     * <p>
+     * Its used when allow field addition feature is enabled.
+     *
+     * @param icebergTable
+     * @param newSchema
+     */
     private void applyFieldAddition(Table icebergTable, Schema newSchema) {
 
         UpdateSchema us = icebergTable.updateSchema().
@@ -115,6 +149,12 @@ public class IcebergTableOperator {
         }
     }
 
+    /**
+     * Adds list of change events to iceberg table. All the events are having same schema.
+     *
+     * @param icebergTable
+     * @param events
+     */
     private void addToTablePerSchema(Table icebergTable, List<IcebergChangeEvent> events) {
         // Initialize a task writer to write both INSERT and equality DELETE.
         BaseTaskWriter<Record> writer = writerFactory.create(icebergTable);
@@ -124,11 +164,11 @@ public class IcebergTableOperator {
             }
 
             writer.close();
-            WriteResult files = writer.complete();
-            RowDelta newRowDelta = icebergTable.newRowDelta();
-            Arrays.stream(files.dataFiles()).forEach(newRowDelta::addRows);
-            Arrays.stream(files.deleteFiles()).forEach(newRowDelta::addDeletes);
-            newRowDelta.commit();
+            WriteResult result = writer.complete();
+            RowDelta rowDelta = icebergTable.newRowDelta();
+            Arrays.stream(result.dataFiles()).forEach(rowDelta::addRows);
+            Arrays.stream(result.deleteFiles()).forEach(rowDelta::addDeletes);
+            rowDelta.commit();
 
         } catch (IOException ex) {
             throw new ConnectException(ex);

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/PartitionedAppendWriter.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/PartitionedAppendWriter.java
@@ -13,7 +13,7 @@ import org.apache.iceberg.io.PartitionedWriter;
 
 public class PartitionedAppendWriter extends PartitionedWriter<Record> {
     private final PartitionKey partitionKey;
-    InternalRecordWrapper wrapper;
+    private final InternalRecordWrapper wrapper;
 
     public PartitionedAppendWriter(PartitionSpec spec, FileFormat format,
                                    FileAppenderFactory<Record> appenderFactory,

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
@@ -197,8 +197,6 @@ class IcebergSinkSystemTest {
     }
 
     private static String getJarPath() {
-        File dir = new File("./target");
-        FileFilter fileFilter = new WildcardFileFilter("kafka-connect-iceberg-sink-*-shaded.jar");
-        return dir.listFiles(fileFilter)[0].getAbsolutePath();
+        return new File("./target/plugin/kafka-connect-iceberg-sink").getAbsolutePath();
     }
 }

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
@@ -62,7 +62,7 @@ class IcebergSinkSystemTest {
     private static final DebeziumConnectContainer debeziumConnectContainer = new DebeziumConnectContainer()
             .withNetwork(network)
             .withKafkaBootstrap(kafkaContainer.getInternalBootstrap())
-            .withPlugin(getJarPath());
+            .withPlugin(getPluginPath());
 
     private static final HttpClient httpClient = HttpClient.newHttpClient();
     private static SparkTestHelper sparkTestHelper;
@@ -194,7 +194,7 @@ class IcebergSinkSystemTest {
         return icebergConfig.toString();
     }
 
-    private static String getJarPath() {
+    private static String getPluginPath() {
         return new File("./target/plugin/kafka-connect-iceberg-sink").getAbsolutePath();
     }
 }

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
@@ -7,7 +7,6 @@ import com.getindata.kafka.connect.iceberg.sink.testresources.MinioTestHelper;
 import com.getindata.kafka.connect.iceberg.sink.testresources.PostgresTestHelper;
 import com.getindata.kafka.connect.iceberg.sink.testresources.SparkTestHelper;
 import com.getindata.kafka.connect.iceberg.sink.testresources.TestConfig;
-import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.BeforeAll;
@@ -19,7 +18,6 @@ import scala.collection.immutable.Seq;
 import scala.jdk.javaapi.CollectionConverters;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -67,7 +65,6 @@ class IcebergSinkSystemTest {
             .withPlugin(getJarPath());
 
     private static final HttpClient httpClient = HttpClient.newHttpClient();
-    ;
     private static SparkTestHelper sparkTestHelper;
     private static MinioTestHelper minioTestHelper;
     private static PostgresTestHelper postgresTestHelper;

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
@@ -2,11 +2,7 @@ package com.getindata.kafka.connect.iceberg.sink;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.getindata.kafka.connect.iceberg.sink.testcontainers.DebeziumConnectContainer;
-import com.getindata.kafka.connect.iceberg.sink.testcontainers.KafkaContainer;
-import com.getindata.kafka.connect.iceberg.sink.testcontainers.PostgresContainer;
-import com.getindata.kafka.connect.iceberg.sink.testcontainers.S3MinioContainer;
-import com.getindata.kafka.connect.iceberg.sink.testcontainers.SchemaRegistryContainer;
+import com.getindata.kafka.connect.iceberg.sink.testcontainers.*;
 import com.getindata.kafka.connect.iceberg.sink.testresources.MinioTestHelper;
 import com.getindata.kafka.connect.iceberg.sink.testresources.PostgresTestHelper;
 import com.getindata.kafka.connect.iceberg.sink.testresources.SparkTestHelper;
@@ -19,9 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.lifecycle.Startables;
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
+import scala.collection.immutable.Seq;
+import scala.jdk.javaapi.CollectionConverters;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -31,13 +26,11 @@ import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.getindata.kafka.connect.iceberg.sink.testresources.TestConfig.TABLE_NAMESPACE;
 import static com.getindata.kafka.connect.iceberg.sink.testresources.TestConfig.TABLE_PREFIX;
@@ -51,7 +44,7 @@ class IcebergSinkSystemTest {
     private static final Network network = Network.newNetwork();
 
     @Container
-    private static final S3MinioContainer s3MinioContainer  = new S3MinioContainer()
+    private static final S3MinioContainer s3MinioContainer = new S3MinioContainer()
             .withNetwork(network);
 
     @Container
@@ -73,8 +66,9 @@ class IcebergSinkSystemTest {
             .withKafkaBootstrap(kafkaContainer.getInternalBootstrap())
             .withPlugin(getJarPath());
 
-    private static final HttpClient httpClient = HttpClient.newHttpClient();;
-    private static SparkTestHelper sparkTestHelper ;
+    private static final HttpClient httpClient = HttpClient.newHttpClient();
+    ;
+    private static SparkTestHelper sparkTestHelper;
     private static MinioTestHelper minioTestHelper;
     private static PostgresTestHelper postgresTestHelper;
 
@@ -98,7 +92,7 @@ class IcebergSinkSystemTest {
 
         Dataset<Row> result = sparkTestHelper.query(query);
         assertThat(result.count()).isEqualTo(1);
-        List<String> row = JavaConverters.seqAsJavaList(JavaConverters.seqAsJavaList(result.getRows(1, 0)).get(1));
+        List<String> row = CollectionConverters.asJava(CollectionConverters.asJava(result.getRows(1, 0)).get(1));
         assertThat(row.get(0)).isEqualTo("123");
         assertThat(row.get(1)).isEqualTo("1");
         assertThat(row.get(2)).isEqualTo("ABC");
@@ -151,8 +145,8 @@ class IcebergSinkSystemTest {
     }
 
     private Map<String, List<String>> toMapById(Seq<Seq<String>> rows) {
-        return JavaConverters.seqAsJavaList(rows).stream()
-                .map(JavaConverters::seqAsJavaList)
+        return CollectionConverters.asJava(rows).stream()
+                .map(CollectionConverters::asJava)
                 .collect(Collectors.toMap(e -> e.get(1), e -> e));
     }
 

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/testcontainers/SchemaRegistryContainer.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/testcontainers/SchemaRegistryContainer.java
@@ -26,7 +26,7 @@ public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryCont
     }
 
     public String getUrl() {
-        return format("http://%s:%d", this.getContainerIpAddress(), this.getMappedPort(SCHEMA_REGISTRY_INTERNAL_PORT));
+        return format("http://%s:%d", this.getHost(), this.getMappedPort(SCHEMA_REGISTRY_INTERNAL_PORT));
     }
 
     public String getInternalUrl() {

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/IcebergChangeEventBuilder.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/IcebergChangeEventBuilder.java
@@ -39,14 +39,14 @@ public class IcebergChangeEventBuilder {
   public IcebergChangeEventBuilder addField(String parentFieldName, String name, String val) {
     ObjectNode nestedField = JsonNodeFactory.instance.objectNode();
     nestedField.put(name, val);
-    this.payload.put(parentFieldName, nestedField);
+    this.payload.set(parentFieldName, nestedField);
     return this;
   }
 
   public IcebergChangeEventBuilder addField(String parentFieldName, String name, int val) {
     ObjectNode nestedField = JsonNodeFactory.instance.objectNode();
     nestedField.put(name, val);
-    this.payload.put(parentFieldName, nestedField);
+    this.payload.set(parentFieldName, nestedField);
     return this;
   }
 
@@ -57,7 +57,7 @@ public class IcebergChangeEventBuilder {
       nestedField = (ObjectNode) this.payload.get(parentFieldName);
     }
     nestedField.put(name, val);
-    this.payload.put(parentFieldName, nestedField);
+    this.payload.set(parentFieldName, nestedField);
     return this;
   }
 

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/TestConfig.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/TestConfig.java
@@ -13,12 +13,12 @@ public class TestConfig {
     public static final String TABLE_NAMESPACE = "debeziumevents";
     public static final String TABLE_PREFIX = "debeziumcdc_";
     public static final String WRITE_FORMAT = "parquet";
-    public static final String DEBEZIUM_CONNECT_IMAGE = "debezium/connect";
+    public static final String DEBEZIUM_CONNECT_IMAGE = "debezium/connect:1.9";
     public static final String POSTGRES_IMAGE = "postgres";
     public static final String MINIO_IMAGE = "minio/minio:latest";
-    public static final String ZOOKEEPER_IMAGE = "confluentinc/cp-zookeeper:7.0.1";
-    public static final String KAFKA_IMAGE = "confluentinc/cp-kafka:7.0.1";
-    public static final String SCHEMA_REGISTRY_IMAGE = "confluentinc/cp-schema-registry:7.0.1";
+    public static final String ZOOKEEPER_IMAGE = "confluentinc/cp-zookeeper:7.2.2";
+    public static final String KAFKA_IMAGE = "confluentinc/cp-kafka:7.2.2";
+    public static final String SCHEMA_REGISTRY_IMAGE = "confluentinc/cp-schema-registry:7.2.2";
 
     public static Builder builder() {
         return new Builder();


### PR DESCRIPTION
#### Description

Reworked Plugin packaging to include default hadoop resources. This allows to use HDFS as a target with HadoopCatalog.
Also Updated Iceberg to 1.0.0, Spark to 3.3 runtime and dependency of Kafka Connect API to 3.2.3

Tested it with a Strimzi Kafka Connect installation
Unit tests run successfully


##### PR Checklist
- [ ] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
