### PR TITLE
Feat/hive metastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Added support for Hive metastore catalog
+
 ## [0.1.3] - 2022-04-11
 
 -   Logger levels changes

--- a/README.md
+++ b/README.md
@@ -81,6 +81,53 @@ AWS credentials can be passed:
 2. Using enviornment variables `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY`
 3. As ~/.aws/config file
 
+### Catalogs
+
+Using `GlueCatalog`
+
+```json
+{
+  "name": "iceberg-sink",
+  "config": {
+    "connector.class": "com.getindata.kafka.connect.iceberg.sink.IcebergSink",
+    "iceberg.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
+    "iceberg.warehouse": "s3a://my_bucket/iceberg",
+    "iceberg.fs.s3a.access.key": "my-aws-access-key",
+    "iceberg.fs.s3a.secret.key": "my-secret-access-key",
+    ...
+  }
+}
+```
+
+Using `HadoopCatalog`
+
+```json
+{
+  "name": "iceberg-sink",
+  "config": {
+    "connector.class": "com.getindata.kafka.connect.iceberg.sink.IcebergSink",
+    "iceberg.catalog-impl": "org.apache.iceberg.hadoop.HadoopCatalog",
+    "iceberg.warehouse": "s3a://my_bucket/iceberg",
+    ...
+  }
+}
+```
+
+Using `HiveCatalog`
+
+```json
+{
+  "name": "iceberg-sink",
+  "config": {
+    "connector.class": "com.getindata.kafka.connect.iceberg.sink.IcebergSink",
+    "iceberg.catalog-impl": "org.apache.iceberg.hive.HiveCatalog",
+    "iceberg.warehouse": "s3a://my_bucket/iceberg",
+    "iceberg.uri": "thrift://localhost:9083",
+    ...
+  }
+}
+```
+
 ## Limitations
 
 ### DDL support

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <parquet.version>1.12.2</parquet.version>
         <hadoop.version>3.3.1</hadoop.version>
         <awssdk.version>2.17.131</awssdk.version>
+        <hive.version>3.1.3</hive.version>
         <!-- Have to use earlier version due to Spark dependency: Scala module 2.12.3 requires Jackson Databind version >= 2.12.0 and < 2.13.0 -->
         <jackson.version>2.12.6</jackson.version>
 
@@ -135,6 +136,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
             <version>${awssdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-metastore</artifactId>
+            <version>${hive.version}</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
@@ -184,6 +184,7 @@ class IcebergSinkSystemTest {
                 "    \"database.server.name\": \"postgres\",\n" +
                 "    \"slot.name\": \"dbzkafkaconnect\",\n" +
                 "    \"plugin.name\": \"pgoutput\",\n" +
+                "    \"topic.prefix\": \"postgres\",\n" +
                 "    \"table.include.list\": \"public.dbz_test,public.dbz_test1,public.dbz_test2\"\n" +
                 "  }\n" +
                 "}";


### PR DESCRIPTION
#### Description

To use catalog-impl `org.apache.iceberg.hive.HiveCatalog` we need to include hive-metastore. Without it, it will throw ClassNotFoundException.

Example config:

```
{
  "name": "iceberg-sink",
  "config": {
    "connector.class": "com.getindata.kafka.connect.iceberg.sink.IcebergSink",
    ...
    "iceberg.catalog-impl": "org.apache.iceberg.hive.HiveCatalog",
    "iceberg.uri": "thrift://localhost:9083",
    ...
  }
}
```

##### PR Checklist
- [ ] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
