### PR TITLE
generic iceberg table properties configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   removed 'table.write-format', can be replaced with 'iceberg.table-default.write.format.default'
+
 ## [0.2.0] - 2022-11-16
 
 -   Added support for Hive metastore catalog

--- a/README.md
+++ b/README.md
@@ -12,21 +12,21 @@ mvn clean package
 
 ### Configuration reference
 
-| Key                  | Type    | Default value  | Description                                                                                                                        |
-|----------------------|---------|----------------|------------------------------------------------------------------------------------------------------------------------------------|
-| upsert               | boolean | true           | When *true* Iceberg rows will be updated based on table primary key. When *false* all modification will be added as separate rows. |
-| upsert.keep-deletes  | boolean | true           | When *true* delete operation will leave a tombstone that will have only a primary key and *__deleted** flag set to true            |
-| upsert.dedup-column  | String  | __source_ts_ms | Column used to check which state is newer during upsert                                                                            | 
-| upsert.op-column     | String  | __op           | Column used to check which state is newer during upsert when *upsert.dedup-column* is not enough to resolve                        |
-| allow-field-addition | boolean | true           | When *true* sink will be adding new columns to Iceberg tables on schema changes                                                    |
-| table.auto-create    | boolean | false          | When *true* sink will automatically create new Iceberg tables                                                                      |
-| table.namespace      | String  | default        | Table namespace. In Glue it will be used as database name                                                                          |
-| table.prefix         | String  | *empty string* | Prefix added to all table names                                                                                                    |
-| table.write-format   | String  | parquet        | Format used for Iceberg tables                                                                                                     |
-| iceberg.name         | String  | default        | Iceberg catalog name                                                                                                               |
-| iceberg.catalog-impl | String  | *null*         | Iceberg catalog implementation (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time    |
-| iceberg.type         | String  | *null*         | Iceberg catalog type (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time)             |
-| iceberg.*            |         |                | All properties with this prefix will be passed to Iceberg Catalog implementation                                                   |
+| Key                     | Type    | Default value  | Description                                                                                                                            |
+|-------------------------|---------|----------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| upsert                  | boolean | true           | When *true* Iceberg rows will be updated based on table primary key. When *false* all modification will be added as separate rows.     |
+| upsert.keep-deletes     | boolean | true           | When *true* delete operation will leave a tombstone that will have only a primary key and *__deleted** flag set to true                |
+| upsert.dedup-column     | String  | __source_ts_ms | Column used to check which state is newer during upsert                                                                                | 
+| upsert.op-column        | String  | __op           | Column used to check which state is newer during upsert when *upsert.dedup-column* is not enough to resolve                            |
+| allow-field-addition    | boolean | true           | When *true* sink will be adding new columns to Iceberg tables on schema changes                                                        |
+| table.auto-create       | boolean | false          | When *true* sink will automatically create new Iceberg tables                                                                          |
+| table.namespace         | String  | default        | Table namespace. In Glue it will be used as database name                                                                              |
+| table.prefix            | String  | *empty string* | Prefix added to all table names                                                                                                        |
+| iceberg.name            | String  | default        | Iceberg catalog name                                                                                                                   |
+| iceberg.catalog-impl    | String  | *null*         | Iceberg catalog implementation (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time        |
+| iceberg.type            | String  | *null*         | Iceberg catalog type (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time)                 |
+| iceberg.*               |         |                | All properties with this prefix will be passed to Iceberg Catalog implementation                                                       |
+| iceberg.table-default.* |         |                | Iceberg specific table settings can be changed with this prefix, e.g. 'iceberg.table-default.write.format.default' can be set to 'orc' |
 
 
 ### REST / Manual based installation

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeConsumer.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeConsumer.java
@@ -60,7 +60,7 @@ public class IcebergChangeConsumer {
             if (!configuration.isTableAutoCreate()) {
                 throw new ConnectException(String.format("Table '%s' not found! Set '%s' to true to create tables automatically!", tableId, TABLE_AUTO_CREATE));
             }
-            return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(), configuration.getTableWriteFormat(), !configuration.isUpsert());
+            return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(), !configuration.isUpsert());
         });
     }
 }

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
@@ -20,7 +20,6 @@ public class IcebergSinkConfiguration {
     public static final String TABLE_NAMESPACE = "table.namespace";
     public static final String TABLE_PREFIX = "table.prefix";
     public static final String TABLE_AUTO_CREATE = "table.auto-create";
-    public static final String TABLE_WRITE_FORMAT = "table.write-format";
     public static final String ICEBERG_PREFIX = "iceberg.";
     public static final String CATALOG_NAME = ICEBERG_PREFIX + "name";
     public static final String CATALOG_IMPL = ICEBERG_PREFIX + "catalog-impl";
@@ -45,8 +44,6 @@ public class IcebergSinkConfiguration {
                     "Table namespace. In Glue it will be used as database name")
             .define(TABLE_PREFIX, STRING, "", MEDIUM,
                     "Prefix added to all table names")
-            .define(TABLE_WRITE_FORMAT, STRING, "parquet", LOW,
-                    "Format used for Iceberg tables")
             .define(CATALOG_NAME, STRING, "default", MEDIUM,
                     "Iceberg catalog name")
             .define(CATALOG_IMPL, STRING, null, MEDIUM,
@@ -97,10 +94,6 @@ public class IcebergSinkConfiguration {
         return parsedConfig.getString(TABLE_PREFIX);
     }
 
-    public String getTableWriteFormat() {
-        return  parsedConfig.getString(TABLE_WRITE_FORMAT);
-    }
-    
     public String getCatalogName() {
         return parsedConfig.getString(CATALOG_NAME);
     }

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergUtil.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergUtil.java
@@ -35,7 +35,7 @@ public class IcebergUtil {
   protected static final ObjectMapper jsonObjectMapper = new ObjectMapper();
 
   public static Table createIcebergTable(Catalog icebergCatalog, TableIdentifier tableIdentifier,
-                                         Schema schema, String writeFormat, boolean partition) {
+                                         Schema schema, boolean partition) {
 
     LOGGER.info("Creating table:'{}'\nschema:{}\nrowIdentifier:{}", tableIdentifier, schema,
         schema.identifierFieldNames());
@@ -49,7 +49,6 @@ public class IcebergUtil {
 
     return icebergCatalog.buildTable(tableIdentifier, schema)
         .withProperty(FORMAT_VERSION, "2")
-        .withProperty(DEFAULT_FILE_FORMAT, writeFormat.toLowerCase(Locale.ENGLISH))
         .withSortOrder(IcebergUtil.getIdentifierFieldsAsSortOrder(schema))
         .withPartitionSpec(ps)
         .create();

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
@@ -185,7 +185,7 @@ class IcebergSinkSystemTest {
         ObjectNode icebergConfig = MAPPER.createObjectNode();
         icebergConfig.put("name", "iceberg-sink");
         ObjectNode configNode = MAPPER.createObjectNode();
-        TestConfig.builder().withS3Url(s3MinioContainer.getInternalUrl()).build()
+        TestConfig.builder().withS3(s3MinioContainer.getInternalUrl()).build()
                 .getProperties()
                 .forEach(configNode::put);
         configNode.put("connector.class", "com.getindata.kafka.connect.iceberg.sink.IcebergSink");

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/TestConfig.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/TestConfig.java
@@ -2,6 +2,7 @@ package com.getindata.kafka.connect.iceberg.sink.testresources;
 
 import com.getindata.kafka.connect.iceberg.sink.IcebergSinkConfiguration;
 
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -12,7 +13,6 @@ public class TestConfig {
     public static final String S3_REGION_NAME = "us-east-1";
     public static final String TABLE_NAMESPACE = "debeziumevents";
     public static final String TABLE_PREFIX = "debeziumcdc_";
-    public static final String WRITE_FORMAT = "parquet";
     public static final String DEBEZIUM_CONNECT_IMAGE = "debezium/connect:1.9";
     public static final String POSTGRES_IMAGE = "postgres";
     public static final String MINIO_IMAGE = "minio/minio:latest";
@@ -25,7 +25,7 @@ public class TestConfig {
     }
 
     public static class Builder {
-        private Map<String, String> properties;
+        private final Map<String, String> properties;
 
         private Builder() {
             properties = new HashMap<>();
@@ -34,6 +34,15 @@ public class TestConfig {
             properties.put(IcebergSinkConfiguration.TABLE_PREFIX, TABLE_PREFIX);
             properties.put(IcebergSinkConfiguration.TABLE_AUTO_CREATE, "true");
             properties.put(IcebergSinkConfiguration.CATALOG_NAME, "iceberg");
+        }
+
+        public Builder withLocalCatalog(Path localWarehouseDir) {
+            properties.put(IcebergSinkConfiguration.CATALOG_TYPE, "hadoop");
+            properties.put("iceberg.warehouse", localWarehouseDir.toUri().toString());
+            return this;
+        }
+
+        public Builder withS3(String s3Url) {
             properties.put(IcebergSinkConfiguration.CATALOG_TYPE, "hadoop");
             properties.put("iceberg.fs.defaultFS", "s3a://" + S3_BUCKET);
             properties.put("iceberg.fs.s3a.endpoint.region", S3_REGION_NAME);
@@ -41,15 +50,17 @@ public class TestConfig {
             properties.put("iceberg.fs.s3a.access.key", S3_ACCESS_KEY);
             properties.put("iceberg.fs.s3a.secret.key", S3_SECRET_KEY);
             properties.put("iceberg.fs.s3a.path.style.access", "true");
-        }
-
-        public Builder withS3Url(String s3Url) {
             properties.put("iceberg.fs.s3a.endpoint", s3Url);
             return this;
         }
 
         public Builder withUpsert(boolean upsert) {
             properties.put(IcebergSinkConfiguration.UPSERT, Boolean.toString(upsert));
+            return this;
+        }
+
+        public Builder withCustomCatalogProperty(String key, String value) {
+            properties.put(IcebergSinkConfiguration.ICEBERG_PREFIX + key, value);
             return this;
         }
 


### PR DESCRIPTION
removed 'table.write-format', 
obsolete due to generic table properties override prefix through catalog config properties

#### Description

simplifying config and making table properties configuration explicit.

Possible due to: 
- https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/CatalogProperties.java#L30
- https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java#L258

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
