### PR TITLE
Allow to change iceberg table properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-   Allow changing iceberg-table specific settings using `iceberg.table-default.*` connector configuration properties
+
 ## [0.2.1] - 2022-12-09
 
 -   removed 'table.write-format', can be replaced with 'iceberg.table-default.write.format.default'

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeConsumer.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeConsumer.java
@@ -60,7 +60,7 @@ public class IcebergChangeConsumer {
             if (!configuration.isTableAutoCreate()) {
                 throw new ConnectException(String.format("Table '%s' not found! Set '%s' to true to create tables automatically!", tableId, TABLE_AUTO_CREATE));
             }
-            return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(), !configuration.isUpsert());
+            return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(), configuration);
         });
     }
 }

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
@@ -21,6 +21,7 @@ public class IcebergSinkConfiguration {
     public static final String TABLE_PREFIX = "table.prefix";
     public static final String TABLE_AUTO_CREATE = "table.auto-create";
     public static final String ICEBERG_PREFIX = "iceberg.";
+    public static final String ICEBERG_TABLE_PREFIX = "iceberg.table-default";
     public static final String CATALOG_NAME = ICEBERG_PREFIX + "name";
     public static final String CATALOG_IMPL = ICEBERG_PREFIX + "catalog-impl";
     public static final String CATALOG_TYPE = ICEBERG_PREFIX + "type";
@@ -99,9 +100,17 @@ public class IcebergSinkConfiguration {
     }
     
     public Map<String, String> getIcebergCatalogConfiguration() {
+        return getConfiguration(ICEBERG_PREFIX);
+    }
+
+    public Map<String, String> getIcebergTableConfiguration() {
+        return getConfiguration(ICEBERG_TABLE_PREFIX);
+    }
+
+    private Map<String, String> getConfiguration(String prefix) {
         Map<String, String> config = new HashMap<>();
-        properties.keySet().stream().filter(key -> key.startsWith(ICEBERG_PREFIX)).forEach(key -> {
-            config.put(key.substring(ICEBERG_PREFIX.length()), properties.get(key));
+        properties.keySet().stream().filter(key -> key.startsWith(prefix)).forEach(key -> {
+            config.put(key.substring(prefix.length()), properties.get(key));
         });
         return config;
     }

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -148,7 +148,7 @@ class TestIcebergUtil {
                 Set.of(1)
         );
 
-        Table table1 = IcebergUtil.createIcebergTable(catalog, TableIdentifier.of("test", "test"), schema, false);
+        Table table1 = IcebergUtil.createIcebergTable(catalog, TableIdentifier.of("test", "test"), schema, config);
 
         assertTrue(IcebergUtil.getTableFileFormat(table1) == FileFormat.ORC);
     }

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/IcebergTableOperatorTest.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/IcebergTableOperatorTest.java
@@ -45,8 +45,12 @@ class IcebergTableOperatorTest {
     }
 
     public Table createTable(IcebergChangeEvent sampleEvent) {
+        IcebergSinkConfiguration config = TestConfig.builder()
+                .withUpsert(false)
+                .build();
+
         final TableIdentifier tableId = TableIdentifier.of(Namespace.of(TABLE_NAMESPACE), TABLE_PREFIX + sampleEvent.destinationTable());
-        return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(), false);
+        return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(), config);
     }
 
     @Test


### PR DESCRIPTION
#### Description

Hi! I've tried connector and found that properties passes like `iceberg.table-default.*` seems to be not working and don't change anything in table. This PR adds (or maybe correctly to say just enable) this feature as it described in README 🙂
Resolves https://github.com/getindata/kafka-connect-iceberg-sink/issues/21

##### PR Checklist
- [x] Tests added
- [ ] [Changelog](CHANGELOG.md) updated 
