### PR TITLE
Add partitioning column configuration setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add `iceberg.partition` config setting to allow any column to be used for partitioning.
+
 ## [0.2.5] - 2023-03-20
 
 -   Reverted pom.xml groupid

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ mvn clean package
 | iceberg.type            | String  | *null*         | Iceberg catalog type (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time)                 |
 | iceberg.*               |         |                | All properties with this prefix will be passed to Iceberg Catalog implementation                                                       |
 | iceberg.table-default.* |         |                | Iceberg specific table settings can be changed with this prefix, e.g. 'iceberg.table-default.write.format.default' can be set to 'orc' |
-
+| iceberg.partition       | String  | __source_ts_ms | Column used for partitioning. Must be a UTC unix millisecond timestamp.                                                                |
 
 ### REST / Manual based installation
 

--- a/README.md
+++ b/README.md
@@ -12,22 +12,23 @@ mvn clean package
 
 ### Configuration reference
 
-| Key                     | Type    | Default value  | Description                                                                                                                            |
-|-------------------------|---------|----------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| upsert                  | boolean | true           | When *true* Iceberg rows will be updated based on table primary key. When *false* all modification will be added as separate rows.     |
-| upsert.keep-deletes     | boolean | true           | When *true* delete operation will leave a tombstone that will have only a primary key and *__deleted** flag set to true                |
-| upsert.dedup-column     | String  | __source_ts_ms | Column used to check which state is newer during upsert                                                                                | 
-| upsert.op-column        | String  | __op           | Column used to check which state is newer during upsert when *upsert.dedup-column* is not enough to resolve                            |
-| allow-field-addition    | boolean | true           | When *true* sink will be adding new columns to Iceberg tables on schema changes                                                        |
-| table.auto-create       | boolean | false          | When *true* sink will automatically create new Iceberg tables                                                                          |
-| table.namespace         | String  | default        | Table namespace. In Glue it will be used as database name                                                                              |
-| table.prefix            | String  | *empty string* | Prefix added to all table names                                                                                                        |
-| iceberg.name            | String  | default        | Iceberg catalog name                                                                                                                   |
-| iceberg.catalog-impl    | String  | *null*         | Iceberg catalog implementation (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time        |
-| iceberg.type            | String  | *null*         | Iceberg catalog type (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time)                 |
-| iceberg.*               |         |                | All properties with this prefix will be passed to Iceberg Catalog implementation                                                       |
-| iceberg.table-default.* |         |                | Iceberg specific table settings can be changed with this prefix, e.g. 'iceberg.table-default.write.format.default' can be set to 'orc' |
-| iceberg.partition       | String  | __source_ts_ms | Column used for partitioning. Must be a UTC unix millisecond timestamp.                                                                |
+| Key                         | Type    | Default value  | Description                                                                                                                                                 |
+|-----------------------------|---------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| upsert                      | boolean | true           | When *true* Iceberg rows will be updated based on table primary key. When *false* all modification will be added as separate rows.                          |
+| upsert.keep-deletes         | boolean | true           | When *true* delete operation will leave a tombstone that will have only a primary key and *__deleted** flag set to true                                     |
+| upsert.dedup-column         | String  | __source_ts_ms | Column used to check which state is newer during upsert                                                                                                     | 
+| upsert.op-column            | String  | __op           | Column used to check which state is newer during upsert when *upsert.dedup-column* is not enough to resolve                                                 |
+| allow-field-addition        | boolean | true           | When *true* sink will be adding new columns to Iceberg tables on schema changes                                                                             |
+| table.auto-create           | boolean | false          | When *true* sink will automatically create new Iceberg tables                                                                                               |
+| table.namespace             | String  | default        | Table namespace. In Glue it will be used as database name                                                                                                   |
+| table.prefix                | String  | *empty string* | Prefix added to all table names                                                                                                                             |
+| iceberg.name                | String  | default        | Iceberg catalog name                                                                                                                                        |
+| iceberg.catalog-impl        | String  | *null*         | Iceberg catalog implementation (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time                             |
+| iceberg.type                | String  | *null*         | Iceberg catalog type (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time)                                      |
+| iceberg.*                   |         |                | All properties with this prefix will be passed to Iceberg Catalog implementation                                                                            |
+| iceberg.table-default.*     |         |                | Iceberg specific table settings can be changed with this prefix, e.g. 'iceberg.table-default.write.format.default' can be set to 'orc'                      |
+| iceberg.partition.column    | String  | __source_ts    | Column used for partitioning. If the column already exists, it must be of type timestamp.                                                                   |
+| iceberg.partition.timestamp | String  | __source_ts_ms | Column containing unix millisecond timestamps to be converted to partitioning times. If equal to partition.column, values will be replaced with timestamps. |
 
 ### REST / Manual based installation
 
@@ -302,9 +303,15 @@ Rows cannot be updated nor removed unless primary key is defined. In case of del
 
 ### Iceberg partitioning support
 
-Currently, partitioning is done automatically based on event time. Partitioning only works when Debezium is configured in append-only mode (`upsert: false`).
+The consumer reads unix millisecond timestamps from the event field configured in `iceberg.partition.timestamp`, converts them to iceberg
+timestamps, and writes them to the table column configured in `iceberg.partition.column`.  The timestamp column is then used to extract a 
+date to be used as the partitioning key. If `iceberg.partition.timestamp` is empty, `iceberg.parition.column` is assumed to already be of 
+type timestamp, and no conversion is performed. If they are set to the same value, the integer values will be replaced by the converted
+timestamp values.
 
-Any event produced by debezium source contains a source time at which the transaction was committed:
+Partitioning only works when configured in append-only mode (`upsert: false`).
+
+By default, the sink expects to receive events produced by a debezium source containing a source time at which the transaction was committed:
 
 ```sql
 "sourceOffset": {
@@ -312,8 +319,6 @@ Any event produced by debezium source contains a source time at which the transa
   "ts_ms": "1482918357011"
 }
 ```
-
-From this value day part is extracted and used as partition.
 
 ## Debezium change event format support
 

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeConsumer.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeConsumer.java
@@ -65,7 +65,7 @@ public class IcebergChangeConsumer {
             if (!configuration.isTableAutoCreate()) {
                 throw new ConnectException(String.format("Table '%s' not found! Set '%s' to true to create tables automatically!", tableId, TABLE_AUTO_CREATE));
             }
-            return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(), configuration);
+            return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(configuration.getPartitionColumn()), configuration);
         });
     }
 }

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeEvent.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeEvent.java
@@ -59,23 +59,26 @@ public class IcebergChangeEvent {
     return jsonSchema;
   }
 
-  public Schema icebergSchema() {
-    return jsonSchema.icebergSchema();
+  public Schema icebergSchema(String partitionColumn) {
+    return jsonSchema.icebergSchema(partitionColumn);
   }
 
   public String destinationTable() {
     return destination.replace(".", "_").replace("-", "_");
   }
 
-  public GenericRecord asIcebergRecord(Schema schema, String partitionColumn) {
+  public GenericRecord asIcebergRecord(Schema schema, String partitionColumn, String partitionTimestampColumn) {
     final GenericRecord record = asIcebergRecord(schema.asStruct(), value);
 
-    if (value != null && value.has(partitionColumn) && value.get(partitionColumn) != null) {
-      final long partitionTimestamp = value.get(partitionColumn).longValue();
-      final OffsetDateTime odt = OffsetDateTime.ofInstant(Instant.ofEpochMilli(partitionTimestamp), ZoneOffset.UTC);
-      record.setField("__source_ts", odt);
-    } else {
-      record.setField("__source_ts", null);
+    if (partitionTimestampColumn != null && !partitionTimestampColumn.equals("")) {
+      // if partitionTimestampColumn is set, convert it to a timestamp and store it in partitionColumn.
+      if (value != null && value.has(partitionTimestampColumn) && value.get(partitionTimestampColumn) != null) {
+        final long partitionTimestamp = value.get(partitionTimestampColumn).longValue();
+        final OffsetDateTime odt = OffsetDateTime.ofInstant(Instant.ofEpochMilli(partitionTimestamp), ZoneOffset.UTC);
+        record.setField(partitionColumn, odt);
+      } else {
+        record.setField(partitionColumn, null);
+      }
     }
     return record;
   }
@@ -119,6 +122,8 @@ public class IcebergChangeEvent {
         return Types.StringType.get();
       case "bytes":
         return Types.BinaryType.get();
+      case "timestamptz":
+        return Types.TimestampType.withZone();
       default:
         // default to String type
         return Types.StringType.get();
@@ -219,22 +224,22 @@ public class IcebergChangeEvent {
       return new ArrayList<>();
     }
 
-    private List<Types.NestedField> valueSchemaFields() {
+    private List<Types.NestedField> valueSchemaFields(String partitionColumn) {
       if (valueSchema != null && valueSchema.has("fields") && valueSchema.get("fields").isArray()) {
         LOGGER.debug(valueSchema.toString());
-        return icebergSchema(valueSchema, "", 0, true);
+        return icebergSchema(valueSchema, "", 0, true, partitionColumn);
       }
       LOGGER.trace("Event schema not found!");
       return new ArrayList<>();
     }
 
-    public Schema icebergSchema() {
+    public Schema icebergSchema(String partitionColumn) {
 
       if (this.valueSchema == null) {
         throw new RuntimeException("Failed to get event schema, event schema is null");
       }
 
-      final List<Types.NestedField> tableColumns = valueSchemaFields();
+      final List<Types.NestedField> tableColumns = valueSchemaFields(partitionColumn);
 
       if (tableColumns.isEmpty()) {
         throw new RuntimeException("Failed to get event schema, event schema has no fields!");
@@ -268,11 +273,11 @@ public class IcebergChangeEvent {
     }
 
     private List<Types.NestedField> icebergSchema(JsonNode eventSchema, String schemaName, int columnId) {
-      return icebergSchema(eventSchema, schemaName, columnId, false);
+      return icebergSchema(eventSchema, schemaName, columnId, false, "");
     }
 
     private List<Types.NestedField> icebergSchema(JsonNode eventSchema, String schemaName, int columnId,
-                                                  boolean addSourceTsField) {
+                                                  boolean addPartitionField, String partitionColumn) {
       List<Types.NestedField> schemaColumns = new ArrayList<>();
       String schemaType = eventSchema.get("type").textValue();
       LOGGER.debug("Converting Schema of: {}::{}", schemaName, schemaType);
@@ -309,14 +314,20 @@ public class IcebergChangeEvent {
             columnId += subSchema.size();
             break;
           default: //primitive types
+            if (fieldName.equals(partitionColumn)) {
+              // if it is the partition column, swap its type to timestamp
+              fieldType = "timestamptz";
+              // we also dont need to add a partition field, since it already exists.
+              addPartitionField = false;
+            }
             schemaColumns.add(Types.NestedField.optional(columnId, fieldName, icebergFieldType(fieldType)));
             break;
         }
       }
 
-      if (addSourceTsField) {
+      if (addPartitionField) {
         columnId++;
-        schemaColumns.add(Types.NestedField.optional(columnId, "__source_ts", Types.TimestampType.withZone()));
+        schemaColumns.add(Types.NestedField.optional(columnId, partitionColumn, Types.TimestampType.withZone()));
       }
       return schemaColumns;
     }

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeEvent.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeEvent.java
@@ -67,12 +67,12 @@ public class IcebergChangeEvent {
     return destination.replace(".", "_").replace("-", "_");
   }
 
-  public GenericRecord asIcebergRecord(Schema schema) {
+  public GenericRecord asIcebergRecord(Schema schema, String partitionColumn) {
     final GenericRecord record = asIcebergRecord(schema.asStruct(), value);
 
-    if (value != null && value.has("__source_ts_ms") && value.get("__source_ts_ms") != null) {
-      final long source_ts_ms = value.get("__source_ts_ms").longValue();
-      final OffsetDateTime odt = OffsetDateTime.ofInstant(Instant.ofEpochMilli(source_ts_ms), ZoneOffset.UTC);
+    if (value != null && value.has(partitionColumn) && value.get(partitionColumn) != null) {
+      final long partitionTimestamp = value.get(partitionColumn).longValue();
+      final OffsetDateTime odt = OffsetDateTime.ofInstant(Instant.ofEpochMilli(partitionTimestamp), ZoneOffset.UTC);
       record.setField("__source_ts", odt);
     } else {
       record.setField("__source_ts", null);

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
@@ -26,7 +26,8 @@ public class IcebergSinkConfiguration {
     public static final String CATALOG_NAME = ICEBERG_PREFIX + "name";
     public static final String CATALOG_IMPL = ICEBERG_PREFIX + "catalog-impl";
     public static final String CATALOG_TYPE = ICEBERG_PREFIX + "type";
-    public static final String PARTITION_COLUMN = ICEBERG_PREFIX + "partition";
+    public static final String PARTITION_TIMESTAMP = ICEBERG_PREFIX + "partition.timestamp";
+    public static final String PARTITION_COLUMN = ICEBERG_PREFIX + "partition.column";
 
     private static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(UPSERT, BOOLEAN, true, MEDIUM,
@@ -58,8 +59,11 @@ public class IcebergSinkConfiguration {
             .define(CATALOG_TYPE, STRING, null, MEDIUM,
                     "Iceberg catalog type (Only one of iceberg.catalog-impl and iceberg.type " +
                             "can be set to non null value at the same time)")
-            .define(PARTITION_COLUMN, STRING, "__source_ts_ms", MEDIUM,
-                    "Column used for partitioning. Must be unix millisecond timestamp.")
+            .define(PARTITION_TIMESTAMP, STRING, "__source_ts_ms", MEDIUM,
+                    "Unix millisecond timestamp used to fill the partitioning column. If set, values"+
+                    "will be converted to a timestamp value and stored in iceberg.partition.column")
+            .define(PARTITION_COLUMN, STRING, "__source_ts", MEDIUM,
+                    "Column used for partitioning. If the column already exists, it must be of type timestamp.")
             ;
     private final AbstractConfig parsedConfig;
     private final Map<String, String> properties;
@@ -109,10 +113,22 @@ public class IcebergSinkConfiguration {
         return parsedConfig.getString(CATALOG_NAME);
     }
 
+    /**
+     * Gets the name of the column used for partitioning the iceberg table.
+     * @return Name of the partitioning column
+     */
     public String getPartitionColumn() {
         return parsedConfig.getString(PARTITION_COLUMN);
     }
-    
+
+    /**
+     * Gets the name of the column containing unix millisecond timestamps to be used for partitioning.
+     * @return Unix timestamp in milliseconds
+     */
+    public String getPartitionTimestamp() {
+        return parsedConfig.getString(PARTITION_TIMESTAMP);
+    }
+
     public Map<String, String> getIcebergCatalogConfiguration() {
         return getConfiguration(ICEBERG_PREFIX);
     }

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
@@ -26,6 +26,8 @@ public class IcebergSinkConfiguration {
     public static final String CATALOG_NAME = ICEBERG_PREFIX + "name";
     public static final String CATALOG_IMPL = ICEBERG_PREFIX + "catalog-impl";
     public static final String CATALOG_TYPE = ICEBERG_PREFIX + "type";
+    public static final String PARTITION_COLUMN = ICEBERG_PREFIX + "partition";
+
     private static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(UPSERT, BOOLEAN, true, MEDIUM,
                     "When true Iceberg rows will be updated based on table primary key. " +
@@ -56,8 +58,9 @@ public class IcebergSinkConfiguration {
             .define(CATALOG_TYPE, STRING, null, MEDIUM,
                     "Iceberg catalog type (Only one of iceberg.catalog-impl and iceberg.type " +
                             "can be set to non null value at the same time)")
+            .define(PARTITION_COLUMN, STRING, "__source_ts_ms", MEDIUM,
+                    "Column used for partitioning. Must be unix millisecond timestamp.")
             ;
-
     private final AbstractConfig parsedConfig;
     private final Map<String, String> properties;
 
@@ -104,6 +107,10 @@ public class IcebergSinkConfiguration {
 
     public String getCatalogName() {
         return parsedConfig.getString(CATALOG_NAME);
+    }
+
+    public String getPartitionColumn() {
+        return parsedConfig.getString(PARTITION_COLUMN);
     }
     
     public Map<String, String> getIcebergCatalogConfiguration() {

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergUtil.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergUtil.java
@@ -42,8 +42,8 @@ public class IcebergUtil {
 
     boolean partition = !configuration.isUpsert();
     final PartitionSpec ps;
-    if (partition && schema.findField("__source_ts") != null) {
-      ps = PartitionSpec.builderFor(schema).day("__source_ts").build();
+    if (partition && schema.findField(configuration.getPartitionColumn()) != null) {
+      ps = PartitionSpec.builderFor(schema).day(configuration.getPartitionColumn()).build();
     } else {
       ps = PartitionSpec.builderFor(schema).build();
     }

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/IcebergTableOperator.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/IcebergTableOperator.java
@@ -64,7 +64,7 @@ public class IcebergTableOperator {
 
             for (Map.Entry<IcebergChangeEvent.JsonSchema, List<IcebergChangeEvent>> schemaEvents : eventsGroupedBySchema.entrySet()) {
                 // extend table schema if new fields found
-                applyFieldAddition(icebergTable, schemaEvents.getKey().icebergSchema());
+                applyFieldAddition(icebergTable, schemaEvents.getKey().icebergSchema(configuration.getPartitionColumn()));
                 // add set of events to table
                 addToTablePerSchema(icebergTable, schemaEvents.getValue());
             }
@@ -160,7 +160,9 @@ public class IcebergTableOperator {
         BaseTaskWriter<Record> writer = writerFactory.create(icebergTable);
         try {
             for (IcebergChangeEvent e : events) {
-                writer.write(e.asIcebergRecord(icebergTable.schema(), configuration.getPartitionColumn()));
+                writer.write(e.asIcebergRecord(icebergTable.schema(),
+                        configuration.getPartitionColumn(),
+                        configuration.getPartitionTimestamp()));
             }
 
             writer.close();

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/IcebergTableOperator.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/IcebergTableOperator.java
@@ -160,7 +160,7 @@ public class IcebergTableOperator {
         BaseTaskWriter<Record> writer = writerFactory.create(icebergTable);
         try {
             for (IcebergChangeEvent e : events) {
-                writer.write(e.asIcebergRecord(icebergTable.schema()));
+                writer.write(e.asIcebergRecord(icebergTable.schema(), configuration.getPartitionColumn()));
             }
 
             writer.close();

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkSystemTest.java
@@ -84,8 +84,12 @@ class IcebergSinkSystemTest {
         postgresTestHelper.execute("create table dbz_test1 (timestamp bigint, id int PRIMARY KEY, value varchar(20))");
         postgresTestHelper.execute("insert into dbz_test1 values(123, 1, 'ABC')");
 
+        var v = sparkTestHelper.query("SELECT 1").count();
+
         String query = "SELECT timestamp, id, value FROM " + getIcebergTableName("dbz_test1");
-        given().ignoreExceptions().await().atMost(Duration.ofSeconds(15)).until(() -> sparkTestHelper.query(query).count() == 1);
+        given().ignoreExceptions().await().atMost(Duration.ofSeconds(1800)).until(() -> {
+            return sparkTestHelper.query(query).count() == 1;
+        });
 
         Dataset<Row> result = sparkTestHelper.query(query);
         assertThat(result.count()).isEqualTo(1);
@@ -118,7 +122,7 @@ class IcebergSinkSystemTest {
         postgresTestHelper.execute("insert into dbz_test2 values(123, 1, 'ABC')");
 
         String query1 = "SELECT timestamp, id, value FROM " + getIcebergTableName("dbz_test2");
-        given().ignoreExceptions().await().atMost(Duration.ofSeconds(15)).until(() -> sparkTestHelper.query(query1).count() == 1);
+        given().ignoreExceptions().await().atMost(Duration.ofSeconds(150)).until(() -> sparkTestHelper.query(query1).count() == 1);
 
         postgresTestHelper.execute("alter table dbz_test2 add column value2 varchar(20)");
         postgresTestHelper.execute("insert into dbz_test2 values(456, 2, 'DEF', 'XYZ')");

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -57,7 +57,7 @@ class TestIcebergUtil {
                 MAPPER.readTree(unwrapWithSchema).get("payload"), null,
                 MAPPER.readTree(unwrapWithSchema).get("schema"), null);
         Schema schema = e.icebergSchema();
-        GenericRecord record = e.asIcebergRecord(schema);
+        GenericRecord record = e.asIcebergRecord(schema, "__source_ts_ms");
         assertEquals("orders", record.getField("__table").toString());
         assertEquals(16850, record.getField("order_date"));
         System.out.println(schema);
@@ -76,7 +76,7 @@ class TestIcebergUtil {
         System.out.println(schema.findField("schedule").type().asListType().elementType());
         assertEquals(schema.findField("pay_by_quarter").type().asListType().elementType().toString(), "int");
         assertEquals(schema.findField("schedule").type().asListType().elementType().toString(), "string");
-        GenericRecord record = e.asIcebergRecord(schema);
+        GenericRecord record = e.asIcebergRecord(schema, "__source_ts_ms");
         assertTrue(record.toString().contains("[10000, 10001, 10002, 10003]"));
     }
 
@@ -100,7 +100,7 @@ class TestIcebergUtil {
                 MAPPER.readTree(unwrapWithGeomSchema).get("payload"), null,
                 MAPPER.readTree(unwrapWithGeomSchema).get("schema"), null);
         Schema schema = e.icebergSchema();
-        GenericRecord record = e.asIcebergRecord(schema);
+        GenericRecord record = e.asIcebergRecord(schema, "__source_ts_ms");
         assertTrue(schema.toString().contains("g: optional struct<3: wkb: optional string, 4: srid: optional int>"));
         GenericRecord g = (GenericRecord) record.getField("g");
         GenericRecord h = (GenericRecord) record.getField("h");

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -41,6 +41,8 @@ class TestIcebergUtil {
     final String unwrapWithArraySchema = Testing.Files.readResourceAsString("json/serde-with-array.json");
     final String unwrapWithArraySchema2 = Testing.Files.readResourceAsString("json/serde-with-array2.json");
 
+    final String customPartitionColumn = Testing.Files.readResourceAsString("json/custom-partition-column.json");
+
     @Test
     public void testNestedJsonRecord() throws JsonProcessingException {
         IcebergChangeEvent e = new IcebergChangeEvent("test",
@@ -108,6 +110,19 @@ class TestIcebergUtil {
         assertEquals(123, g.get(1, Types.IntegerType.get().typeId().javaClass()));
         assertEquals("Record(null, null)", h.toString());
         assertNull(h.get(0, Types.BinaryType.get().typeId().javaClass()));
+    }
+
+    @Test
+    public void testCustomPartitionColumnRecord() throws IOException {
+        IcebergChangeEvent e = new IcebergChangeEvent("test",
+                MAPPER.readTree(customPartitionColumn).get("payload"), null,
+                MAPPER.readTree(customPartitionColumn).get("schema"), null);
+        Schema schema = e.icebergSchema();
+        GenericRecord record = e.asIcebergRecord(schema, "timestamp");
+        assertEquals("2023-03-20T18:25:27.865Z", record.getField("__source_ts").toString());
+        assertEquals("hello", record.getField("message"));
+        System.out.println(schema);
+        System.out.println(record);
     }
 
     @Test

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/IcebergTableOperatorTest.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/tableoperator/IcebergTableOperatorTest.java
@@ -50,7 +50,7 @@ class IcebergTableOperatorTest {
                 .build();
 
         final TableIdentifier tableId = TableIdentifier.of(Namespace.of(TABLE_NAMESPACE), TABLE_PREFIX + sampleEvent.destinationTable());
-        return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(), config);
+        return IcebergUtil.createIcebergTable(icebergCatalog, tableId, sampleEvent.icebergSchema(config.getPartitionColumn()), config);
     }
 
     @Test

--- a/src/test/resources/json/custom-partition-column.json
+++ b/src/test/resources/json/custom-partition-column.json
@@ -1,0 +1,22 @@
+{
+  "schema": {
+    "type": "struct",
+    "optional": false,
+    "fields": [
+      {
+        "type": "string",
+        "optional": false,
+        "field": "message"
+      },
+      {
+        "type": "int32",
+        "optional": false,
+        "field": "timestamp"
+      }
+    ]
+  },
+  "payload": {
+    "message": "hello",
+    "timestamp": 1679336727865
+  }
+}


### PR DESCRIPTION
#### Description

Adds a configuration setting that allows the user to specify which column is used for partitioning. The column must be a unix millisecond timestamp.

This implementation seems to work for my use case, what do you think? @gliter 

Resolves #18 

##### PR Checklist
- [x] Tests added
- [x] [Changelog](CHANGELOG.md) updated 
