### PR TITLE
Support iceberg format version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,67 +2,60 @@
 
 ## [Unreleased]
 
+- Add `iceberg.format-version` config setting to indicate which Iceberg table format version is used.
+
 ## [0.3.0] - 2023-03-24
 
--   Add `iceberg.partition` config setting to allow any column to be used for partitioning.
+- Add `iceberg.partition` config setting to allow any column to be used for partitioning.
 
 ## [0.2.5] - 2023-03-20
 
--   Reverted pom.xml groupid
+- Reverted pom.xml groupid
 
 ## [0.2.4] - 2023-03-13
 
--   Added support for `double` primitive type fields.
--   Allow coercion of iceberg table identifiers to `snake_case` setting `table.snake-case` boolean configuration.
+- Added support for `double` primitive type fields.
+- Allow coercion of iceberg table identifiers to `snake_case` setting `table.snake-case` boolean configuration.
 
 ## [0.2.2] - 2023-02-17
 
--   Allow changing iceberg-table specific settings using `iceberg.table-default.*` connector configuration properties
+- Allow changing iceberg-table specific settings using `iceberg.table-default.*` connector configuration properties
 
 ## [0.2.1] - 2022-12-09
 
--   removed 'table.write-format', can be replaced with 'iceberg.table-default.write.format.default'
+- removed 'table.write-format', can be replaced with 'iceberg.table-default.write.format.default'
 
 ## [0.2.0] - 2022-11-16
 
--   Added support for Hive metastore catalog
--   Replaced maven-shade plugin with maven-assembly. To add hadoop default configuration files
--   Integrated updates from <https://github.com/memiiso/debezium-server-iceberg>
--   Updated Iceberg to 1.0.0
--   Updated to Kafka Connect API 3.2.2
+- Added support for Hive metastore catalog
+- Replaced maven-shade plugin with maven-assembly. To add hadoop default configuration files
+- Integrated updates from <https://github.com/memiiso/debezium-server-iceberg>
+- Updated Iceberg to 1.0.0
+- Updated to Kafka Connect API 3.2.2
 
 ### Version Compatibility
 
-This Iceberg Sink depends on a Spark 3.2 Runtime, which depends on a specific jackson minor version. 
+This Iceberg Sink depends on a Spark 3.2 Runtime, which depends on a specific jackson minor version.
 Kafka Connect >= 3.2.3 has updated the jackson version to an incompatible minor release (2.13)
 
 ## [0.1.3] - 2022-04-11
 
--   Logger levels changes
--   Added documentation to sink configuration
+- Logger levels changes
+- Added documentation to sink configuration
 
 ## [0.1.2] - 2022-03-25
 
 ## [0.1.1] - 2022-03-25
 
--   First release
+- First release
 
-[Unreleased]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.3.0...HEAD
-
+[unreleased]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.3.0...HEAD
 [0.3.0]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.2.5...0.3.0
-
 [0.2.5]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.2.4...0.2.5
-
 [0.2.4]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.2.2...0.2.4
-
 [0.2.2]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.2.1...0.2.2
-
 [0.2.1]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.2.0...0.2.1
-
 [0.2.0]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.1.3...0.2.0
-
 [0.1.3]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.1.2...0.1.3
-
 [0.1.2]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/0.1.1...0.1.2
-
 [0.1.1]: https://github.com/getindata/kafka-connect-iceberg-sink/compare/1190003ddc686273cb9ad28ce7dd2d8e458471d7...0.1.1

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ mvn clean package
 | iceberg.table-default.\*    |         |                  | Iceberg specific table settings can be changed with this prefix, e.g. 'iceberg.table-default.write.format.default' can be set to 'orc'                      |
 | iceberg.partition.column    | String  | \_\_source_ts    | Column used for partitioning. If the column already exists, it must be of type timestamp.                                                                   |
 | iceberg.partition.timestamp | String  | \_\_source_ts_ms | Column containing unix millisecond timestamps to be converted to partitioning times. If equal to partition.column, values will be replaced with timestamps. |
-| iceberg.format-version      | String  | \_\_source_ts_ms | Specification for the Iceberg table formatg. Version 1: Analytic Data Tables. Version 2: Row-level Deletes. Default 2.                                      |
+| iceberg.format-version      | String  | 2                | Specification for the Iceberg table format. Version 1: Analytic Data Tables. Version 2: Row-level Deletes. Default 2.                                       |
 
 ### REST / Manual based installation
 

--- a/README.md
+++ b/README.md
@@ -12,44 +12,46 @@ mvn clean package
 
 ### Configuration reference
 
-| Key                         | Type    | Default value  | Description                                                                                                                                                 |
-|-----------------------------|---------|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| upsert                      | boolean | true           | When *true* Iceberg rows will be updated based on table primary key. When *false* all modification will be added as separate rows.                          |
-| upsert.keep-deletes         | boolean | true           | When *true* delete operation will leave a tombstone that will have only a primary key and *__deleted** flag set to true                                     |
-| upsert.dedup-column         | String  | __source_ts_ms | Column used to check which state is newer during upsert                                                                                                     | 
-| upsert.op-column            | String  | __op           | Column used to check which state is newer during upsert when *upsert.dedup-column* is not enough to resolve                                                 |
-| allow-field-addition        | boolean | true           | When *true* sink will be adding new columns to Iceberg tables on schema changes                                                                             |
-| table.auto-create           | boolean | false          | When *true* sink will automatically create new Iceberg tables                                                                                               |
-| table.namespace             | String  | default        | Table namespace. In Glue it will be used as database name                                                                                                   |
-| table.prefix                | String  | *empty string* | Prefix added to all table names                                                                                                                             |
-| iceberg.name                | String  | default        | Iceberg catalog name                                                                                                                                        |
-| iceberg.catalog-impl        | String  | *null*         | Iceberg catalog implementation (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time                             |
-| iceberg.type                | String  | *null*         | Iceberg catalog type (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time)                                      |
-| iceberg.*                   |         |                | All properties with this prefix will be passed to Iceberg Catalog implementation                                                                            |
-| iceberg.table-default.*     |         |                | Iceberg specific table settings can be changed with this prefix, e.g. 'iceberg.table-default.write.format.default' can be set to 'orc'                      |
-| iceberg.partition.column    | String  | __source_ts    | Column used for partitioning. If the column already exists, it must be of type timestamp.                                                                   |
-| iceberg.partition.timestamp | String  | __source_ts_ms | Column containing unix millisecond timestamps to be converted to partitioning times. If equal to partition.column, values will be replaced with timestamps. |
+| Key                         | Type    | Default value    | Description                                                                                                                                                 |
+| --------------------------- | ------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| upsert                      | boolean | true             | When _true_ Iceberg rows will be updated based on table primary key. When _false_ all modification will be added as separate rows.                          |
+| upsert.keep-deletes         | boolean | true             | When _true_ delete operation will leave a tombstone that will have only a primary key and \*\_\_deleted\*\* flag set to true                                |
+| upsert.dedup-column         | String  | \_\_source_ts_ms | Column used to check which state is newer during upsert                                                                                                     |
+| upsert.op-column            | String  | \_\_op           | Column used to check which state is newer during upsert when _upsert.dedup-column_ is not enough to resolve                                                 |
+| allow-field-addition        | boolean | true             | When _true_ sink will be adding new columns to Iceberg tables on schema changes                                                                             |
+| table.auto-create           | boolean | false            | When _true_ sink will automatically create new Iceberg tables                                                                                               |
+| table.namespace             | String  | default          | Table namespace. In Glue it will be used as database name                                                                                                   |
+| table.prefix                | String  | _empty string_   | Prefix added to all table names                                                                                                                             |
+| iceberg.name                | String  | default          | Iceberg catalog name                                                                                                                                        |
+| iceberg.catalog-impl        | String  | _null_           | Iceberg catalog implementation (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time                             |
+| iceberg.type                | String  | _null_           | Iceberg catalog type (Only one of iceberg.catalog-impl and iceberg.type can be set to non null value at the same time)                                      |
+| iceberg.\*                  |         |                  | All properties with this prefix will be passed to Iceberg Catalog implementation                                                                            |
+| iceberg.table-default.\*    |         |                  | Iceberg specific table settings can be changed with this prefix, e.g. 'iceberg.table-default.write.format.default' can be set to 'orc'                      |
+| iceberg.partition.column    | String  | \_\_source_ts    | Column used for partitioning. If the column already exists, it must be of type timestamp.                                                                   |
+| iceberg.partition.timestamp | String  | \_\_source_ts_ms | Column containing unix millisecond timestamps to be converted to partitioning times. If equal to partition.column, values will be replaced with timestamps. |
+| iceberg.format-version      | String  | \_\_source_ts_ms | Specification for the Iceberg table formatg. Version 1: Analytic Data Tables. Version 2: Row-level Deletes. Default 2.                                      |
 
 ### REST / Manual based installation
 
 1. Copy content of `kafka-connect-iceberg-sink-0.1.4-SNAPSHOT-plugin.zip` into Kafka Connect plugins directory. [Kafka Connect installing plugins](https://docs.confluent.io/home/connect/self-managed/userguide.html#connect-installing-plugins)
 
 2. POST `<kafka_connect_host>:<kafka_connect_port>/connectors`
+
 ```json
 {
   "name": "iceberg-sink",
   "config": {
     "connector.class": "com.getindata.kafka.connect.iceberg.sink.IcebergSink",
     "topics": "topic1,topic2",
-    
+
     "upsert": true,
     "upsert.keep-deletes": true,
-    
+
     "table.auto-create": true,
     "table.write-format": "parquet",
     "table.namespace": "my_namespace",
     "table.prefix": "debeziumcdc_",
-    
+
     "iceberg.catalog-impl": "org.apache.iceberg.aws.glue.GlueCatalog",
     "iceberg.warehouse": "s3a://my_bucket/iceberg",
     "iceberg.fs.defaultFS": "s3a://my_bucket/iceberg",
@@ -81,6 +83,7 @@ docker run -it --name connect --net=host -p 8083:8083 \
 ### Strimzi
 
 KafkaConnect:
+
 ```yaml
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnect
@@ -122,19 +125,19 @@ spec:
     config.providers.secret.class: io.strimzi.kafka.KubernetesSecretConfigProvider
     config.providers.configmap.class: io.strimzi.kafka.KubernetesConfigMapConfigProvider
   build:
-      output:
-        type: docker
-        image: <yourdockerregistry>
-        pushSecret: <yourpushSecret>
-      plugins:
-        - name: debezium-postgresql
-          artifacts:
-            - type: zip
-              url: https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/2.0.0.Final/debezium-connector-postgres-2.0.0.Final-plugin.zip
-        - name: iceberg
-          artifacts:
-            - type: zip
-              url: https://github.com/TIKI-Institut/kafka-connect-iceberg-sink/releases/download/0.1.4-SNAPSHOT-hadoop-catalog-r3/kafka-connect-iceberg-sink-0.1.4-SNAPSHOT-plugin.zip
+    output:
+      type: docker
+      image: <yourdockerregistry>
+      pushSecret: <yourpushSecret>
+    plugins:
+      - name: debezium-postgresql
+        artifacts:
+          - type: zip
+            url: https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/2.0.0.Final/debezium-connector-postgres-2.0.0.Final-plugin.zip
+      - name: iceberg
+        artifacts:
+          - type: zip
+            url: https://github.com/TIKI-Institut/kafka-connect-iceberg-sink/releases/download/0.1.4-SNAPSHOT-hadoop-catalog-r3/kafka-connect-iceberg-sink-0.1.4-SNAPSHOT-plugin.zip
   resources:
     requests:
       cpu: "0.1"
@@ -151,6 +154,7 @@ spec:
 ```
 
 KafkaConnector Debezium Source
+
 ```yaml
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnector
@@ -182,6 +186,7 @@ spec:
 ```
 
 KafkaConnector Iceberg Sink:
+
 ```yaml
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnector
@@ -212,8 +217,8 @@ spec:
     iceberg.io-impl: "org.apache.iceberg.aws.s3.S3FileIO"
     iceberg.s3.endpoint: "http://minio:9000"
     iceberg.s3.path-style-access: true
-    iceberg.s3.access-key-id: ''
-    iceberg.s3.secret-access-key: ''
+    iceberg.s3.access-key-id: ""
+    iceberg.s3.secret-access-key: ""
     # Batch size tuning
     # See: https://stackoverflow.com/questions/51753883/increase-the-number-of-messages-read-by-a-kafka-consumer-in-a-single-poll
     # And the key prefix in Note: https://stackoverflow.com/a/66551961/2688589
@@ -225,6 +230,7 @@ spec:
 #### Hadoop s3a
 
 AWS credentials can be passed:
+
 1. As part of sink configuration under keys `iceberg.fs.s3a.access.key` and `iceberg.fs.s3a.secret.key`
 2. Using enviornment variables `AWS_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY`
 3. As ~/.aws/config file
@@ -299,13 +305,13 @@ Similar problem is with changing optionality of a column. If it was not defined 
 
 ### DML
 
-Rows cannot be updated nor removed unless primary key is defined. In case of deletion sink behavior is also dependent on upsert.keep-deletes option. When this option is set to true sink will leave a tombstone behind in a form of row containing only a primary key value and __deleted flat set to true. When option is set to false it will remove row entirely.
+Rows cannot be updated nor removed unless primary key is defined. In case of deletion sink behavior is also dependent on upsert.keep-deletes option. When this option is set to true sink will leave a tombstone behind in a form of row containing only a primary key value and \_\_deleted flat set to true. When option is set to false it will remove row entirely.
 
 ### Iceberg partitioning support
 
 The consumer reads unix millisecond timestamps from the event field configured in `iceberg.partition.timestamp`, converts them to iceberg
-timestamps, and writes them to the table column configured in `iceberg.partition.column`.  The timestamp column is then used to extract a 
-date to be used as the partitioning key. If `iceberg.partition.timestamp` is empty, `iceberg.parition.column` is assumed to already be of 
+timestamps, and writes them to the table column configured in `iceberg.partition.column`. The timestamp column is then used to extract a
+date to be used as the partitioning key. If `iceberg.partition.timestamp` is empty, `iceberg.parition.column` is assumed to already be of
 type timestamp, and no conversion is performed. If they are set to the same value, the integer values will be replaced by the converted
 timestamp values.
 
@@ -322,7 +328,7 @@ By default, the sink expects to receive events produced by a debezium source con
 
 ## Debezium change event format support
 
-Kafka Connect Iceberg Sink is expecting events in a format of *Debezium change event*. It uses however only an *after* portion of that event and some metadata.
+Kafka Connect Iceberg Sink is expecting events in a format of _Debezium change event_. It uses however only an _after_ portion of that event and some metadata.
 Minimal fields needed for the sink to work are:
 
 Kafka event key:

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
@@ -66,7 +66,7 @@ public class IcebergSinkConfiguration {
                     "will be converted to a timestamp value and stored in iceberg.partition.column")
             .define(PARTITION_COLUMN, STRING, "__source_ts", MEDIUM,
                     "Column used for partitioning. If the column already exists, it must be of type timestamp.")
-            .define(FORMAT_VERSION, STRING, "__source_ts", MEDIUM,
+            .define(FORMAT_VERSION, STRING, "2", MEDIUM,
                     "Specification for the Iceberg table formatg. Version 1: Analytic Data Tables."+
                     "Version 2: Row-level Deletes. Default 2.");
                     

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergSinkConfiguration.java
@@ -28,6 +28,8 @@ public class IcebergSinkConfiguration {
     public static final String CATALOG_TYPE = ICEBERG_PREFIX + "type";
     public static final String PARTITION_TIMESTAMP = ICEBERG_PREFIX + "partition.timestamp";
     public static final String PARTITION_COLUMN = ICEBERG_PREFIX + "partition.column";
+    public static final String FORMAT_VERSION = ICEBERG_PREFIX + "format-version";
+
 
     private static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(UPSERT, BOOLEAN, true, MEDIUM,
@@ -64,7 +66,10 @@ public class IcebergSinkConfiguration {
                     "will be converted to a timestamp value and stored in iceberg.partition.column")
             .define(PARTITION_COLUMN, STRING, "__source_ts", MEDIUM,
                     "Column used for partitioning. If the column already exists, it must be of type timestamp.")
-            ;
+            .define(FORMAT_VERSION, STRING, "__source_ts", MEDIUM,
+                    "Specification for the Iceberg table formatg. Version 1: Analytic Data Tables."+
+                    "Version 2: Row-level Deletes. Default 2.");
+                    
     private final AbstractConfig parsedConfig;
     private final Map<String, String> properties;
 
@@ -119,6 +124,10 @@ public class IcebergSinkConfiguration {
      */
     public String getPartitionColumn() {
         return parsedConfig.getString(PARTITION_COLUMN);
+    }
+
+    public String getFormatVersion() {
+        return parsedConfig.getString(FORMAT_VERSION);
     }
 
     /**

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergUtil.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergUtil.java
@@ -48,9 +48,13 @@ public class IcebergUtil {
       ps = PartitionSpec.builderFor(schema).build();
     }
 
+    String formatVersion = "2";
+    if(configuration.getFormatVersion()){
+      formatVersion=configuration.getFormatVersion();
+    }
     return icebergCatalog.buildTable(tableIdentifier, schema)
         .withProperties(configuration.getIcebergTableConfiguration())
-        .withProperty(FORMAT_VERSION, "2")
+        .withProperty(FORMAT_VERSION, formatVersion)
         .withSortOrder(IcebergUtil.getIdentifierFieldsAsSortOrder(schema))
         .withPartitionSpec(ps)
         .create();

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergUtil.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergUtil.java
@@ -49,7 +49,7 @@ public class IcebergUtil {
     }
 
     String formatVersion = "2";
-    if(configuration.getFormatVersion()){
+    if(configuration.getFormatVersion() != null && !"".equals(configuration.getFormatVersion())){
       formatVersion=configuration.getFormatVersion();
     }
     return icebergCatalog.buildTable(tableIdentifier, schema)

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergUtil.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergUtil.java
@@ -35,7 +35,7 @@ public class IcebergUtil {
   protected static final ObjectMapper jsonObjectMapper = new ObjectMapper();
 
   public static Table createIcebergTable(Catalog icebergCatalog, TableIdentifier tableIdentifier,
-                                         Schema schema, IcebergSinkConfiguration configuration) {
+      Schema schema, IcebergSinkConfiguration configuration) {
 
     LOGGER.info("Creating table:'{}'\nschema:{}\nrowIdentifier:{}", tableIdentifier, schema,
         schema.identifierFieldNames());
@@ -49,8 +49,8 @@ public class IcebergUtil {
     }
 
     String formatVersion = "2";
-    if(configuration.getFormatVersion() != null && !"".equals(configuration.getFormatVersion())){
-      formatVersion=configuration.getFormatVersion();
+    if (configuration.getFormatVersion() != null && !"".equals(configuration.getFormatVersion())) {
+      formatVersion = configuration.getFormatVersion();
     }
     return icebergCatalog.buildTable(tableIdentifier, schema)
         .withProperties(configuration.getIcebergTableConfiguration())
@@ -94,43 +94,43 @@ public class IcebergUtil {
   }
 
   public static String toSnakeCase(String inputString) {
-      
-      StringBuilder sb = new StringBuilder();
-      boolean lastUpper = true;
-      boolean lastSeparator = false;
 
-      for (Character c : inputString.toCharArray()) {
-          
-          if (Character.isUpperCase(c)) {
+    StringBuilder sb = new StringBuilder();
+    boolean lastUpper = true;
+    boolean lastSeparator = false;
 
-              if (!lastUpper) {
+    for (Character c : inputString.toCharArray()) {
 
-                  if (!lastSeparator) {
-                      sb.append("_");
-                  }
+      if (Character.isUpperCase(c)) {
 
-                  lastUpper = true;
-              }
+        if (!lastUpper) {
 
-              sb.append(Character.toLowerCase(c));
-              lastSeparator = false;
+          if (!lastSeparator) {
+            sb.append("_");
           }
-          
-          else {
-              
-              if (c == '_') {
-                  lastSeparator = true;
-              }
 
-              else {
-                  lastSeparator = false;
-              }
-              
-              sb.append(c);
-              lastUpper = false;
-          }
+          lastUpper = true;
+        }
+
+        sb.append(Character.toLowerCase(c));
+        lastSeparator = false;
       }
-      
-      return sb.toString();
+
+      else {
+
+        if (c == '_') {
+          lastSeparator = true;
+        }
+
+        else {
+          lastSeparator = false;
+        }
+
+        sb.append(c);
+        lastUpper = false;
+      }
+    }
+
+    return sb.toString();
   }
 }

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -185,6 +185,30 @@ class TestIcebergUtil {
     }
 
     @Test
+    public void createIcebergTablesWithCustomPropertiesFormatVersion(@TempDir Path localWarehouseDir) {
+        IcebergSinkConfiguration config = TestConfig.builder()
+                .withLocalCatalog(localWarehouseDir)
+                .withUpsert(false)
+                .withCustomCatalogProperty("table-default.write.format.default", "orc")
+                .withFormatVersion("1")
+                .build();
+
+        Catalog catalog = IcebergCatalogFactory.create(config);
+
+        Schema schema = new Schema(
+                List.of(
+                        Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                        Types.NestedField.required(2, "data", Types.StringType.get())),
+                Set.of(1)
+        );
+
+        Table table1 = IcebergUtil.createIcebergTable(catalog, TableIdentifier.of("test", "test"), schema, config);
+
+        assertTrue(IcebergUtil.getTableFileFormat(table1) == FileFormat.ORC);
+    }
+
+
+    @Test
     public void testToSnakeCase() {
         assertTrue(IcebergUtil.toSnakeCase("armadillo_pension").equals("armadillo_pension"));
         assertTrue(IcebergUtil.toSnakeCase("TurboPascal").equals("turbo_pascal"));

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/TestConfig.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/TestConfig.java
@@ -65,7 +65,7 @@ public class TestConfig {
         }
 
         public Builder withFormatVersion(String formatVersion) {
-            properties.put(IcebergSinkConfiguration.FORMAT_VERSION, formatVersion));
+            properties.put(IcebergSinkConfiguration.FORMAT_VERSION, formatVersion);
             return this;
         }
 

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/TestConfig.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/testresources/TestConfig.java
@@ -64,6 +64,11 @@ public class TestConfig {
             return this;
         }
 
+        public Builder withFormatVersion(String formatVersion) {
+            properties.put(IcebergSinkConfiguration.FORMAT_VERSION, formatVersion));
+            return this;
+        }
+
         public IcebergSinkConfiguration build() {
             return new IcebergSinkConfiguration(properties);
         }


### PR DESCRIPTION
#### Description

`Some solutions like Dremio only support for now Apache Iceberg in its format version 1. Here it's a proposition to facilitate the management of iceberg.format-version config parameter (Version 1: Analytic Data Tables. Version 2: Row-level Deletes. Default 2.) and allow to set the version of Apache Iceberg format version we want that sink connector populates. 

With this enhancement of the connector Dremio recognize better the Apache Iceberg format.
