### PR TITLE
Support another rich temporal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+- Support debezium mysql Rich temporal type: org.apache.kafka.connect.data.Timestamp
+- Epoch time to timestamp bug fix
+- Rich temporal types are documented
+
 ## [0.4.0] - 2023-05-25
 
 -   Updates dependencies to resolve some jackson-databind critical CVEs.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ mvn clean package
 | iceberg.partition.column    | String  | \_\_source_ts    | Column used for partitioning. If the column already exists, it must be of type timestamp.                                                                   |
 | iceberg.partition.timestamp | String  | \_\_source_ts_ms | Column containing unix millisecond timestamps to be converted to partitioning times. If equal to partition.column, values will be replaced with timestamps. |
 | iceberg.format-version      | String  | 2                | Specification for the Iceberg table format. Version 1: Analytic Data Tables. Version 2: Row-level Deletes. Default 2.                                       |
+| rich-temporal-types         | boolean | false            | Coerce Debezium Date, MicroTimestamp, ZonedTimestamp, MicroTime, and ZonedTime values from JSON primitives to their corresponding Iceberg rich types        |
 
 ### REST / Manual based installation
 

--- a/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeEvent.java
+++ b/src/main/java/com/getindata/kafka/connect/iceberg/sink/IcebergChangeEvent.java
@@ -119,6 +119,10 @@ public class IcebergChangeEvent {
           return Types.TimestampType.withoutZone();
         }
         else if (configuration.isRichTemporalTypes() &&
+                fieldTypeName.equals("org.apache.kafka.connect.data.Timestamp")) {
+          return Types.TimestampType.withoutZone();
+        }
+        else if (configuration.isRichTemporalTypes() &&
                  fieldTypeName.equals("io.debezium.time.MicroTime")) {
           return Types.TimeType.get();
         }
@@ -189,7 +193,7 @@ public class IcebergChangeEvent {
           val = OffsetDateTime.parse(node.asText());
         }
         else if (node.isNumber()) {
-          Instant instant = Instant.ofEpochSecond(0L, node.asLong() * 1000);
+          Instant instant = Instant.ofEpochMilli(node.asLong());
           val = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
         }
         else if (node.isNull()){

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -282,6 +282,7 @@ class TestIcebergUtil {
         assertTrue(schemaString.contains("ship_timestamp: optional timestamp (io.debezium.time.MicroTimestamp)"));
         assertTrue(recordString.contains("2182-08-20"));
         assertTrue(recordString.contains("2020-08-01T19:24:29.322"));
+        assertTrue(recordString.contains("2020-08-01T19:24:59.322"));
     }
 
     @Test

--- a/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
+++ b/src/test/java/com/getindata/kafka/connect/iceberg/sink/TestIcebergUtil.java
@@ -192,7 +192,7 @@ class TestIcebergUtil {
 
         GenericRecord record = event.asIcebergRecord(schema, defaultPartitionColumn, defaultPartitionTimestamp);
         assertEquals(record.getField("ship_date"), 77663);
-        assertEquals(record.getField("ship_timestamp"), 6710075456016196L);
+        assertEquals(record.getField("ship_timestamp"), 1596309869322L);
         assertEquals(record.getField("ship_timestamp_zoned"), "2023-04-11T20:32:46.821144Z");
         assertEquals(record.getField("ship_time"), 73966821144L);
         assertEquals(record.getField("ship_time_zoned"), "20:32:46.821144Z");
@@ -281,7 +281,7 @@ class TestIcebergUtil {
         assertTrue(schemaString.contains("ship_date: optional date (io.debezium.time.Date)"));
         assertTrue(schemaString.contains("ship_timestamp: optional timestamp (io.debezium.time.MicroTimestamp)"));
         assertTrue(recordString.contains("2182-08-20"));
-        assertTrue(recordString.contains("2182-08-19T21:50:56.016196"));
+        assertTrue(recordString.contains("2020-08-01T19:24:29.322"));
     }
 
     @Test

--- a/src/test/resources/json/debezium-annotated-schema.json
+++ b/src/test/resources/json/debezium-annotated-schema.json
@@ -49,7 +49,7 @@
   "payload": {
     "id": 10003,
     "ship_date": 77663,
-    "ship_timestamp": 6710075456016196,
+    "ship_timestamp": 1596309869322,
     "ship_timestamp_zoned": "2023-04-11T20:32:46.821144Z",
     "ship_time": 73966821144,
     "ship_time_zoned": "20:32:46.821144Z",

--- a/src/test/resources/json/debezium-annotated-schema.json
+++ b/src/test/resources/json/debezium-annotated-schema.json
@@ -21,6 +21,12 @@
         "field": "ship_timestamp"
       },
       {
+        "type": "int64",
+        "optional": true,
+        "name": "org.apache.kafka.connect.data.Timestamp",
+        "field": "another_ship_timestamp"
+      },
+      {
         "type": "string",
         "optional": true,
         "name": "io.debezium.time.ZonedTimestamp",
@@ -50,6 +56,7 @@
     "id": 10003,
     "ship_date": 77663,
     "ship_timestamp": 1596309869322,
+    "another_ship_timestamp": 1596309899322,
     "ship_timestamp_zoned": "2023-04-11T20:32:46.821144Z",
     "ship_time": 73966821144,
     "ship_time_zoned": "20:32:46.821144Z",


### PR DESCRIPTION
#### Description
- Debezium over MySQL creates an unsupported temporal type: `org.apache.kafka.connect.data.Timestamp`. I added support to it as a timestamp without a timezone.
- Function to convert epoch to timestamp returns the wrong date, Its mainly returns dates from the beginning of 1970 because of the calculation of seconds - Changed it from `ofEpochSecond` into `ofEpochMilli`
- Added missing documentation about `rich-temporal-types` flag


Resolves [`#8`](https://github.com/getindata/kafka-connect-iceberg-sink/issues/8)

##### PR Checklist
- [x] Tests added - Tests fixed
- [x] [Changelog](CHANGELOG.md) updated 
